### PR TITLE
Fix DENSIFY formula leading equals sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ v1.0.3 Removes empty or incomplete rows and columns from sparse data. Use mode t
 **Formula**
 
 ```
-=LET(
+LET(
   actual_mode, IF(OR(mode="", mode=0), "both", LOWER(TRIM(mode))),
   mode_parts, SPLIT(actual_mode, "-"),
   dimension, INDEX(mode_parts, 1),

--- a/formulas/densify.yaml
+++ b/formulas/densify.yaml
@@ -19,7 +19,7 @@ parameters:
     example: "rows-any"
 
 formula: |
-  =LET(
+  LET(
     actual_mode, IF(OR(mode="", mode=0), "both", LOWER(TRIM(mode))),
     mode_parts, SPLIT(actual_mode, "-"),
     dimension, INDEX(mode_parts, 1),


### PR DESCRIPTION
## Summary
- Removes the leading `=` character from the DENSIFY formula to comply with the new `no-leading-equals` linting rule
- This fix ensures the linter checks pass in the CI workflow

## Changes
- Updated `formulas/densify.yaml` to remove `=` from the beginning of the formula field
- Regenerated `README.md` to reflect the corrected formula

## Test plan
- ✅ Linter passes: `python scripts/lint_formulas.py`
- ✅ README generation succeeds: `python scripts/generate_readme.py`
- [x] CI checks pass on PR

Fixes the failing linter check from PR #45.