### PR TITLE
Add GitHub API access note to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,3 +154,4 @@ The composition system uses pyparsing to:
 - **README.md is auto-generated**: Edit `.readme-template.md` for static content changes
 - **Use `uv` not `pip`**: The project uses `uv` for dependency management
 - **Formula composition**: Formulas can reference other named functions - the system will automatically expand them
+- **GitHub API access**: If `gh` CLI is unavailable, check for `$GITHUB_TOKEN` with `[ -n "$GITHUB_TOKEN" ] && echo "✓ Available"` and use with `curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/...` for GitHub operations


### PR DESCRIPTION
## Summary
Adds documentation note about using `$GITHUB_TOKEN` with curl for GitHub API operations when `gh` CLI is unavailable.

## Changes
- Added one-line note to "Notes for Claude Code" section in CLAUDE.md
- Shows how to safely check for token availability without exposing it
- Provides example curl syntax for GitHub API access

## Details
This helps future Claude Code instances discover and use the GitHub API when working in environments where the `gh` CLI tool isn't installed but authentication tokens are available.