### PR TITLE
Add SUBSTITUTEMULTI function for advanced text substitution

### DIFF
--- a/formulas/substitutemulti.yaml
+++ b/formulas/substitutemulti.yaml
@@ -1,0 +1,58 @@
+name: SUBSTITUTEMULTI
+version: 1.0.0
+
+description: >
+  Applies multiple SUBSTITUTE operations sequentially using a two-column mapping range.
+  Substitutions are applied in row order, with later substitutions operating on the
+  results of earlier ones. This enables powerful multi-stage text transformations.
+
+parameters:
+  - name: text
+    description: Text to perform substitutions on (single cell or range)
+    example: "A1:A10"
+
+  - name: mappings
+    description: Two-column range where column 1 contains text to find and column 2 contains replacement text. Substitutions are applied sequentially in row order.
+    example: "B1:C5"
+
+formula: |
+  LET(
+    num_mappings, ROWS(mappings),
+
+    _validate_mappings, IF(COLUMNS(mappings) <> 2,
+      ERROR("Mappings must be a two-column range"),
+      TRUE
+    ),
+
+    _validate_rows, IF(num_mappings < 1,
+      ERROR("Mappings must have at least 1 row"),
+      TRUE
+    ),
+
+    substitution_func, LAMBDA(accumulated_text, row_num,
+      LET(
+        search_text, INDEX(mappings, row_num, 1),
+        replace_text, INDEX(mappings, row_num, 2),
+
+        IF(OR(search_text = "", ISBLANK(search_text)),
+          accumulated_text,
+          SUBSTITUTE(accumulated_text, search_text, replace_text)
+        )
+      )
+    ),
+
+    IF(OR(ROWS(text) > 1, COLUMNS(text) > 1),
+      MAP(text, LAMBDA(cell,
+        REDUCE(
+          cell,
+          SEQUENCE(num_mappings),
+          substitution_func
+        )
+      )),
+      REDUCE(
+        text,
+        SEQUENCE(num_mappings),
+        substitution_func
+      )
+    )
+  )


### PR DESCRIPTION
## Summary

Implements issue #17 by creating a more powerful version of SUBSTITUTE that accepts a two-column mapping range instead of single value pairs.

### Implementation Approach

Used **Option 1: Sequential/Iterative Substitution** approach where:
- Substitutions are applied sequentially in row order using REDUCE
- Later substitutions operate on the results of earlier ones
- Users control behavior by arranging the row order in the mapping range
- Empty/blank search patterns are automatically skipped

### Features

- **Two-column mapping range**: Column 1 contains text to find, Column 2 contains replacement text
- **Sequential application**: Enables multi-stage transformations (e.g., normalize → clean → format)
- **Range support**: Works with both single cells and ranges via MAP
- **Input validation**: Validates that mappings is a two-column range

### Example Usage

```
SUBSTITUTEMULTI(A1, B1:C3)
```

Where B1:C3 contains:
| Search | Replace |
|--------|--------|
| old1   | new1   |
| old2   | new2   |
| old3   | new3   |

This is equivalent to:
```
SUBSTITUTE(SUBSTITUTE(SUBSTITUTE(A1, "old1", "new1"), "old2", "new2"), "old3", "new3")
```

## Test Plan

- [x] Created formula YAML file following project schema
- [x] Ran linter - all checks passed
- [x] Generated README - formula properly documented and expanded
- [ ] Manual testing in Google Sheets (recommended before merge)
  - Test with single cell input
  - Test with range input
  - Test with empty search patterns
  - Test sequential substitution behavior

Closes #17