### PR TITLE
Add uv installation step to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Summary

Adds the `astral-sh/setup-uv@v7` action to the Claude workflow, making `uv` available when Claude operates in the repository via GitHub Actions.

## Problem

Fixes #33

The `claude.yml` workflow allows Claude to use `uv` commands via the `--allowed-tools` configuration:
```yaml
claude_args: '--allowed-tools Bash(git:*) Bash(uv:*) Bash(python*:*)'
```

However, `uv` was not installed in the GitHub Actions Ubuntu runner environment, causing `uv run` commands to fail with "command not found" errors.

## Solution

Added the official `astral-sh/setup-uv@v7` action before the "Run Claude Code" step. This approach:

- ✅ Uses the **official recommended method** from Astral documentation
- ✅ Enables **built-in caching** for faster workflow runs
- ✅ Requires **zero additional configuration** - works out-of-the-box
- ✅ Aligns with the existing `generate-readme.yml` workflow which already uses this approach
- ✅ Makes the repository's tooling **consistent** across local development and CI environments

## Changes

```yaml
- name: Install uv
  uses: astral-sh/setup-uv@v7
  with:
    enable-cache: true
```

## Testing

To verify this fix works:
1. Merge this PR
2. Trigger the Claude workflow by mentioning `@claude` in an issue/PR comment
3. Have Claude run a `uv run` command (e.g., `uv run scripts/generate_readme.py`)
4. Confirm the command executes successfully

## References

- [Using uv in GitHub Actions | uv](https://docs.astral.sh/uv/guides/integration/github/)
- [astral-sh/setup-uv on GitHub Marketplace](https://github.com/marketplace/actions/astral-sh-setup-uv)