### PR TITLE
Fix GitHub API authentication pattern in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,4 +154,4 @@ The composition system uses pyparsing to:
 - **README.md is auto-generated**: Edit `.readme-template.md` for static content changes
 - **Use `uv` not `pip`**: The project uses `uv` for dependency management
 - **Formula composition**: Formulas can reference other named functions - the system will automatically expand them
-- **GitHub API access**: If `gh` CLI is unavailable, check for `$GITHUB_TOKEN` with `[ -n "$GITHUB_TOKEN" ] && echo "✓ Available"` and use with `curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/...` for GitHub operations
+- **GitHub API access**: If `gh` CLI is unavailable, check for `$GITHUB_TOKEN` with `[ -n "$GITHUB_TOKEN" ] && echo "✓ Available"` and use with `curl -s -u "token:$GITHUB_TOKEN" https://api.github.com/repos/...` for GitHub operations. Note: Use the `-u` flag with `"token:$GITHUB_TOKEN"` format for basic authentication, NOT the Authorization header format.


### PR DESCRIPTION
## Summary

Updates the GitHub API access documentation in CLAUDE.md to use the correct authentication method.

## Changes

- Fixed curl command to use `-u "token:$GITHUB_TOKEN"` (basic auth format) instead of the Authorization header format
- Added explicit note about using the `-u` flag for basic authentication

## Why

The previous documentation showed an incorrect authentication pattern. This fix ensures future Claude Code sessions can successfully access the GitHub API on the first try without requiring troubleshooting.

## Test Plan

Tested and verified that basic auth (`-u "token:$GITHUB_TOKEN"`) works for both:
- Reading from GitHub API (GET requests)
- Writing to GitHub API (POST requests to create PRs)

Also verified that Authorization header methods (Bearer and token) do NOT work with fine-grained PATs in this environment.