### PR TITLE
Fix: Remove top-level LAMBDA wrappers from formula definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,9 +265,7 @@ v1.0.0 Converts a cell or range reference to its A1 notation string representati
 **Formula**
 
 ```
-LAMBDA(cell,
-  ADDRESS(ROW(cell), COLUMN(cell), 4)
-)
+ADDRESS(ROW(cell), COLUMN(cell), 4)
 ```
 
 #### cell
@@ -588,9 +586,7 @@ v1.0.0 Displays a custom error message as an #N/A error with a configurable tool
 **Formula**
 
 ```
-LAMBDA(message,
-  XLOOKUP(message, IF(FALSE, {1}), IF(FALSE, {1}))
-)
+XLOOKUP(message, IF(FALSE, {1}), IF(FALSE, {1}))
 ```
 
 #### message
@@ -949,7 +945,7 @@ v1.0.0 Checks if a cell is either truly blank (ISBLANK) or an empty string ("").
 **Formula**
 
 ```
-LAMBDA(cell, OR(ISBLANK(cell), cell = ""))
+OR(ISBLANK(cell), cell = "")
 ```
 
 #### cell
@@ -1156,15 +1152,13 @@ v1.0.0 Converts a range reference to its A1 notation string representation. Retu
 **Formula**
 
 ```
-LAMBDA(range,
-  LET(
-    topLeftCell, ADDRESS(ROW(range), COLUMN(range), 4),
-    bottomRightCell, ADDRESS(ROW(range) + ROWS(range) - 1, COLUMN(range) + COLUMNS(range) - 1, 4),
-    IF(
-      topLeftCell = bottomRightCell,
-      topLeftCell,
-      topLeftCell & ":" & bottomRightCell
-    )
+LET(
+  topLeftCell, ADDRESS(ROW(range), COLUMN(range), 4),
+  bottomRightCell, ADDRESS(ROW(range) + ROWS(range) - 1, COLUMN(range) + COLUMNS(range) - 1, 4),
+  IF(
+    topLeftCell = bottomRightCell,
+    topLeftCell,
+    topLeftCell & ":" & bottomRightCell
   )
 )
 ```
@@ -1303,48 +1297,46 @@ v1.0.0 Returns text that appears after a specified delimiter. Supports forward/b
 **Formula**
 
 ```
-LAMBDA(text, delimiter, instance_num, match_mode, match_end, if_not_found,
-  LET(
+LET(
+  
+  IF(instance_num = 0, NA(),
     
-    IF(instance_num = 0, NA(),
-      
-      IF(delimiter = "",
-        IF(instance_num > 0, text, ""),
-        LET(
-          
-          search_text, IF(match_mode = 1, UPPER(text), text),
-          search_delim, IF(match_mode = 1, UPPER(delimiter), delimiter),
+    IF(delimiter = "",
+      IF(instance_num > 0, text, ""),
+      LET(
+        
+        search_text, IF(match_mode = 1, UPPER(text), text),
+        search_delim, IF(match_mode = 1, UPPER(delimiter), delimiter),
 
-          
-          total_count, (LEN(search_text) - LEN(SUBSTITUTE(search_text, search_delim, ""))) / LEN(search_delim),
+        
+        total_count, (LEN(search_text) - LEN(SUBSTITUTE(search_text, search_delim, ""))) / LEN(search_delim),
 
-          
-          positive_inst, IF(instance_num < 0, total_count + instance_num + 1, instance_num),
+        
+        positive_inst, IF(instance_num < 0, total_count + instance_num + 1, instance_num),
 
-          
-          found, positive_inst > 0 AND positive_inst <= total_count,
+        
+        found, positive_inst > 0 AND positive_inst <= total_count,
 
-          IF(found,
-            LET(
-              
-              
-              marker, "§§§TEXTAFTER§§§",
-              text_with_marker, SUBSTITUTE(search_text, search_delim, marker, positive_inst),
-              delim_pos, FIND(marker, text_with_marker),
-
-              
-              after_pos, delim_pos + LEN(delimiter),
-
-              
-              MID(text, after_pos, LEN(text))
-            ),
+        IF(found,
+          LET(
             
-            IF(match_end = 1,
-              
-              IF(instance_num > 0, "", text),
-              
-              if_not_found
-            )
+            
+            marker, "§§§TEXTAFTER§§§",
+            text_with_marker, SUBSTITUTE(search_text, search_delim, marker, positive_inst),
+            delim_pos, FIND(marker, text_with_marker),
+
+            
+            after_pos, delim_pos + LEN(delimiter),
+
+            
+            MID(text, after_pos, LEN(text))
+          ),
+          
+          IF(match_end = 1,
+            
+            IF(instance_num > 0, "", text),
+            
+            if_not_found
           )
         )
       )
@@ -1642,9 +1634,7 @@ v1.0.0 Wraps content with opening and closing delimiters. Useful for generating 
 **Formula**
 
 ```
-LAMBDA(delimiter, contents,
-  "<" & delimiter & ">" & contents & "</" & delimiter & ">"
-)
+"<" & delimiter & ">" & contents & "</" & delimiter & ">"
 ```
 
 #### delimiter

--- a/formulas/cellref.yaml
+++ b/formulas/cellref.yaml
@@ -13,6 +13,4 @@ parameters:
     example: "N6"
 
 formula: |
-  LAMBDA(cell,
-    ADDRESS(ROW(cell), COLUMN(cell), 4)
-  )
+  ADDRESS(ROW(cell), COLUMN(cell), 4)

--- a/formulas/error.yaml
+++ b/formulas/error.yaml
@@ -12,6 +12,4 @@ parameters:
     example: '"Value must be between 1 and 100"'
 
 formula: |
-  LAMBDA(message,
-    XLOOKUP(message, IF(FALSE, {1}), IF(FALSE, {1}))
-  )
+  XLOOKUP(message, IF(FALSE, {1}), IF(FALSE, {1}))

--- a/formulas/isblanklike.yaml
+++ b/formulas/isblanklike.yaml
@@ -13,4 +13,4 @@ parameters:
     example: "A1"
 
 formula: |
-  LAMBDA(cell, OR(ISBLANK(cell), cell = ""))
+  OR(ISBLANK(cell), cell = "")

--- a/formulas/rangeref.yaml
+++ b/formulas/rangeref.yaml
@@ -14,14 +14,12 @@ parameters:
     example: "A1:B10"
 
 formula: |
-  LAMBDA(range,
-    LET(
-      topLeftCell, ADDRESS(ROW(range), COLUMN(range), 4),
-      bottomRightCell, ADDRESS(ROW(range) + ROWS(range) - 1, COLUMN(range) + COLUMNS(range) - 1, 4),
-      IF(
-        topLeftCell = bottomRightCell,
-        topLeftCell,
-        topLeftCell & ":" & bottomRightCell
-      )
+  LET(
+    topLeftCell, ADDRESS(ROW(range), COLUMN(range), 4),
+    bottomRightCell, ADDRESS(ROW(range) + ROWS(range) - 1, COLUMN(range) + COLUMNS(range) - 1, 4),
+    IF(
+      topLeftCell = bottomRightCell,
+      topLeftCell,
+      topLeftCell & ":" & bottomRightCell
     )
   )

--- a/formulas/textafter.yaml
+++ b/formulas/textafter.yaml
@@ -32,48 +32,46 @@ parameters:
     example: 'NA()'
 
 formula: |
-  LAMBDA(text, delimiter, instance_num, match_mode, match_end, if_not_found,
-    LET(
-      // Validate instance_num is not 0
-      IF(instance_num = 0, NA(),
-        // Special case: empty delimiter
-        IF(delimiter = "",
-          IF(instance_num > 0, text, ""),
-          LET(
-            // Handle case sensitivity for search
-            search_text, IF(match_mode = 1, UPPER(text), text),
-            search_delim, IF(match_mode = 1, UPPER(delimiter), delimiter),
+  LET(
+    // Validate instance_num is not 0
+    IF(instance_num = 0, NA(),
+      // Special case: empty delimiter
+      IF(delimiter = "",
+        IF(instance_num > 0, text, ""),
+        LET(
+          // Handle case sensitivity for search
+          search_text, IF(match_mode = 1, UPPER(text), text),
+          search_delim, IF(match_mode = 1, UPPER(delimiter), delimiter),
 
-            // Count total occurrences of delimiter
-            total_count, (LEN(search_text) - LEN(SUBSTITUTE(search_text, search_delim, ""))) / LEN(search_delim),
+          // Count total occurrences of delimiter
+          total_count, (LEN(search_text) - LEN(SUBSTITUTE(search_text, search_delim, ""))) / LEN(search_delim),
 
-            // Convert negative instance_num to positive (count from right)
-            positive_inst, IF(instance_num < 0, total_count + instance_num + 1, instance_num),
+          // Convert negative instance_num to positive (count from right)
+          positive_inst, IF(instance_num < 0, total_count + instance_num + 1, instance_num),
 
-            // Check if the requested instance exists
-            found, positive_inst > 0 AND positive_inst <= total_count,
+          // Check if the requested instance exists
+          found, positive_inst > 0 AND positive_inst <= total_count,
 
-            IF(found,
-              LET(
-                // Find position of nth delimiter using SUBSTITUTE trick
-                // Replace only the nth occurrence with a unique marker
-                marker, "§§§TEXTAFTER§§§",
-                text_with_marker, SUBSTITUTE(search_text, search_delim, marker, positive_inst),
-                delim_pos, FIND(marker, text_with_marker),
+          IF(found,
+            LET(
+              // Find position of nth delimiter using SUBSTITUTE trick
+              // Replace only the nth occurrence with a unique marker
+              marker, "§§§TEXTAFTER§§§",
+              text_with_marker, SUBSTITUTE(search_text, search_delim, marker, positive_inst),
+              delim_pos, FIND(marker, text_with_marker),
 
-                // Position after the delimiter in original text
-                after_pos, delim_pos + LEN(delimiter),
+              // Position after the delimiter in original text
+              after_pos, delim_pos + LEN(delimiter),
 
-                // Extract and return text after delimiter
-                MID(text, after_pos, LEN(text))
-              ),
-              // Delimiter not found - handle based on match_end
-              IF(match_end = 1,
-                // With match_end=1, treat end of text as delimiter
-                IF(instance_num > 0, "", text),
-                // Return custom error value
-                if_not_found
-              )
+              // Extract and return text after delimiter
+              MID(text, after_pos, LEN(text))
+            ),
+            // Delimiter not found - handle based on match_end
+            IF(match_end = 1,
+              // With match_end=1, treat end of text as delimiter
+              IF(instance_num > 0, "", text),
+              // Return custom error value
+              if_not_found
             )
           )
         )

--- a/formulas/wrap.yaml
+++ b/formulas/wrap.yaml
@@ -15,6 +15,4 @@ parameters:
     example: "A1"
 
 formula: |
-  LAMBDA(delimiter, contents,
-    "<" & delimiter & ">" & contents & "</" & delimiter & ">"
-  )
+  "<" & delimiter & ">" & contents & "</" & delimiter & ">"

--- a/scripts/lint_formulas.py
+++ b/scripts/lint_formulas.py
@@ -70,12 +70,85 @@ class NoLeadingEqualsRule(LintRule):
         return errors
 
 
+class NoTopLevelLambdaRule(LintRule):
+    """Rule: Formula field must not start with uninvoked LAMBDA wrapper."""
+
+    def __init__(self):
+        super().__init__(
+            name="no-top-level-lambda",
+            description="Formula field must not start with uninvoked LAMBDA wrapper (Google Sheets adds this automatically)"
+        )
+
+    def check(self, file_path: Path, data: Dict[str, Any]) -> List[str]:
+        errors = []
+
+        if 'formula' not in data:
+            return errors  # Skip if no formula field
+
+        formula = data['formula']
+        if not isinstance(formula, str):
+            return errors  # Skip if formula is not a string
+
+        # Check if formula starts with LAMBDA (ignoring leading whitespace and trailing whitespace)
+        stripped = formula.strip()
+        if stripped.upper().startswith('LAMBDA('):
+            # Check if it's a self-executing LAMBDA (ends with invocation like )(0) or )(args))
+            # Self-executing LAMBDAs are valid for parameterless functions
+            # Pattern: LAMBDA(...)(...)
+
+            # Count parentheses to find where the LAMBDA definition ends
+            paren_count = 0
+            in_string = False
+            escape_next = False
+            lambda_end = -1
+
+            for i, char in enumerate(stripped):
+                if escape_next:
+                    escape_next = False
+                    continue
+
+                if char == '\\':
+                    escape_next = True
+                    continue
+
+                if char == '"':
+                    in_string = not in_string
+                    continue
+
+                if not in_string:
+                    if char == '(':
+                        paren_count += 1
+                    elif char == ')':
+                        paren_count -= 1
+                        if paren_count == 0:
+                            lambda_end = i
+                            break
+
+            # Check if there's an immediate invocation after the LAMBDA
+            if lambda_end >= 0 and lambda_end < len(stripped) - 1:
+                after_lambda = stripped[lambda_end + 1:].lstrip()
+                if after_lambda.startswith('('):
+                    # This is a self-executing LAMBDA, which is valid
+                    return errors
+
+            # This is an uninvoked LAMBDA - flag it
+            errors.append(
+                f"{file_path}: Formula starts with uninvoked LAMBDA wrapper. "
+                f"Google Sheets adds the LAMBDA wrapper automatically when you define parameters. "
+                f"Only include the formula body in the YAML file. "
+                f"Note: Self-executing LAMBDAs like 'LAMBDA(...)(...)' are allowed for parameterless functions."
+            )
+
+        return errors
+
+
 class FormulaLinter:
     """Main linter class that runs all validation rules."""
 
     def __init__(self):
         self.rules: List[LintRule] = [
             NoLeadingEqualsRule(),
+            NoTopLevelLambdaRule(),
             # Add more rules here as needed
         ]
 


### PR DESCRIPTION
## Summary

Fixes the issue where ERROR, CELLREF, RANGEREF, ISBLANKLIKE, TEXTAFTER, and WRAP formulas caused "Function LAMBDA should be followed by a call containing the actual values" error in Google Sheets Named Functions.

## Problem

When creating Named Functions in Google Sheets, the interface automatically wraps the formula body in a LAMBDA function based on the parameters you define. If the YAML file already contains an **uninvoked** LAMBDA wrapper, this results in double-wrapping:

```
LAMBDA(param1, LAMBDA(param1, formula_body))  ← Double wrapped!
```

This causes Google Sheets to return the inner LAMBDA function instead of executing it, resulting in the error.

## Important Distinction: Uninvoked vs Self-Executing LAMBDAs

The fix distinguishes between two patterns:

1. **Uninvoked LAMBDA** (wrong): `LAMBDA(message, XLOOKUP(...))`
   - Returns a function instead of executing it
   - Causes the error when Google Sheets wraps it again

2. **Self-executing LAMBDA** (valid): `LAMBDA(input, IF(,,))(0)`
   - Creates and immediately invokes the LAMBDA
   - Valid for parameterless functions where immediate evaluation is needed
   - Used by BLANK function to return a truly blank value

## Changes

### Formula Fixes
Removed **uninvoked** LAMBDA wrappers from 6 formula files:
- `formulas/cellref.yaml` - Changed from `LAMBDA(cell, ADDRESS(...))` to `ADDRESS(...)`
- `formulas/error.yaml` - Changed from `LAMBDA(message, XLOOKUP(...))` to `XLOOKUP(...)`
- `formulas/isblanklike.yaml` - Changed from `LAMBDA(cell, OR(...))` to `OR(...)`
- `formulas/rangeref.yaml` - Changed from `LAMBDA(range, LET(...))` to `LET(...)`
- `formulas/textafter.yaml` - Changed from `LAMBDA(..., LET(...))` to `LET(...)`
- `formulas/wrap.yaml` - Changed from `LAMBDA(delimiter, contents, ...)` to direct concatenation

**Kept** self-executing LAMBDA in:
- `formulas/blank.yaml` - Preserved `LAMBDA(input, IF(,,))(0)` pattern (parameterless function)

### Linter Enhancement
Added smart `NoTopLevelLambdaRule` to `scripts/lint_formulas.py`:
- Detects **uninvoked** LAMBDAs and flags them as errors
- **Allows** self-executing LAMBDAs like `LAMBDA(...)(...)` for parameterless functions
- Uses parenthesis counting to detect immediate invocation
- Provides clear error messages explaining the difference

### Documentation
- Updated `README.md` with corrected formula expansions

## Test Plan
- [x] Run `uv run scripts/lint_formulas.py` - All 21 files pass (including BLANK with self-executing LAMBDA)
- [x] Run `uv run scripts/generate_readme.py` - README generated successfully
- [ ] Test ERROR and CELLREF functions in Google Sheets to verify they work correctly

## Impact

This fix makes ERROR, CELLREF, and other affected functions usable in Google Sheets Named Functions. Users can now properly validate staff members and display helpful error messages as shown in the original issue.

The enhanced linter ensures future formulas follow the correct pattern while allowing valid self-executing LAMBDA patterns for special cases.