### PR TITLE
Fix DENSIFY formula syntax error - missing closing parentheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ LET(
         LET(
           threshold, IF(has_any, COLUMNS(range), 1),
           result, IF(has_strict,
-            FILTER(range, BYROW(range, LAMBDA(r, SUMPRODUCT((IFERROR(LEN(TRIM(r)) > 0, TRUE)) * 1) >= threshold)),
+            FILTER(range, BYROW(range, LAMBDA(r, SUMPRODUCT((IFERROR(LEN(TRIM(r)) > 0, TRUE)) * 1) >= threshold))),
             FILTER(range, BYROW(range, LAMBDA(r, COUNTA(r) >= threshold)))
           ),
           IF(ISNA(ROWS(result)), BLANK(), result)
@@ -404,7 +404,7 @@ LET(
           transposed, TRANSPOSE(rows_filtered),
           threshold, IF(has_any, ROWS(rows_filtered), 1),
           result, IF(has_strict,
-            FILTER(transposed, BYROW(transposed, LAMBDA(c, SUMPRODUCT((IFERROR(LEN(TRIM(c)) > 0, TRUE)) * 1) >= threshold)),
+            FILTER(transposed, BYROW(transposed, LAMBDA(c, SUMPRODUCT((IFERROR(LEN(TRIM(c)) > 0, TRUE)) * 1) >= threshold))),
             FILTER(transposed, BYROW(transposed, LAMBDA(c, COUNTA(c) >= threshold)))
           ),
           IF(ISNA(ROWS(result)), BLANK(), TRANSPOSE(result))
@@ -468,7 +468,7 @@ v2.0.0 Removes rows that are entirely blank from sparse data. This is a convenie
 **Formula**
 
 ```
-(LET(
+=LET(
   actual_mode, IF(OR("rows"="", "rows"=0), "both", LOWER(TRIM("rows"))),
   mode_parts, SPLIT(actual_mode, "-"),
   dimension, INDEX(mode_parts, 1),
@@ -486,7 +486,7 @@ v2.0.0 Removes rows that are entirely blank from sparse data. This is a convenie
         LET(
           threshold, IF(has_any, COLUMNS(range), 1),
           result, IF(has_strict,
-            FILTER(range, BYROW(range, LAMBDA(r, SUMPRODUCT((IFERROR(LEN(TRIM(r)) > 0, TRUE)) * 1) >= threshold)),
+            FILTER(range, BYROW(range, LAMBDA(r, SUMPRODUCT((IFERROR(LEN(TRIM(r)) > 0, TRUE)) * 1) >= threshold))),
             FILTER(range, BYROW(range, LAMBDA(r, COUNTA(r) >= threshold)))
           ),
           IF(ISNA(ROWS(result)), BLANK(), result)
@@ -499,7 +499,7 @@ v2.0.0 Removes rows that are entirely blank from sparse data. This is a convenie
           transposed, TRANSPOSE(rows_filtered),
           threshold, IF(has_any, ROWS(rows_filtered), 1),
           result, IF(has_strict,
-            FILTER(transposed, BYROW(transposed, LAMBDA(c, SUMPRODUCT((IFERROR(LEN(TRIM(c)) > 0, TRUE)) * 1) >= threshold)),
+            FILTER(transposed, BYROW(transposed, LAMBDA(c, SUMPRODUCT((IFERROR(LEN(TRIM(c)) > 0, TRUE)) * 1) >= threshold))),
             FILTER(transposed, BYROW(transposed, LAMBDA(c, COUNTA(c) >= threshold)))
           ),
           IF(ISNA(ROWS(result)), BLANK(), TRANSPOSE(result))
@@ -510,7 +510,7 @@ v2.0.0 Removes rows that are entirely blank from sparse data. This is a convenie
       final
     )
   )
-))
+)
 ```
 
 #### range

--- a/formulas/densify.yaml
+++ b/formulas/densify.yaml
@@ -39,7 +39,7 @@ formula: |
           LET(
             threshold, IF(has_any, COLUMNS(range), 1),
             result, IF(has_strict,
-              FILTER(range, BYROW(range, LAMBDA(r, SUMPRODUCT((IFERROR(LEN(TRIM(r)) > 0, TRUE)) * 1) >= threshold)),
+              FILTER(range, BYROW(range, LAMBDA(r, SUMPRODUCT((IFERROR(LEN(TRIM(r)) > 0, TRUE)) * 1) >= threshold))),
               FILTER(range, BYROW(range, LAMBDA(r, COUNTA(r) >= threshold)))
             ),
             IF(ISNA(ROWS(result)), BLANK(), result)
@@ -52,7 +52,7 @@ formula: |
             transposed, TRANSPOSE(rows_filtered),
             threshold, IF(has_any, ROWS(rows_filtered), 1),
             result, IF(has_strict,
-              FILTER(transposed, BYROW(transposed, LAMBDA(c, SUMPRODUCT((IFERROR(LEN(TRIM(c)) > 0, TRUE)) * 1) >= threshold)),
+              FILTER(transposed, BYROW(transposed, LAMBDA(c, SUMPRODUCT((IFERROR(LEN(TRIM(c)) > 0, TRUE)) * 1) >= threshold))),
               FILTER(transposed, BYROW(transposed, LAMBDA(c, COUNTA(c) >= threshold)))
             ),
             IF(ISNA(ROWS(result)), BLANK(), TRANSPOSE(result))


### PR DESCRIPTION
## Summary

Fixes a syntax error in the DENSIFY formula that caused "Formula parse error; check formula syntax" in Google Sheets.

## Problem

The FILTER/BYROW/LAMBDA expressions in strict mode were missing closing parentheses:
- Row filtering (line 42): Had 2 closing parens, needed 3
- Column filtering (line 55): Had 2 closing parens, needed 3

Each expression opens 3 functions (FILTER, BYROW, LAMBDA) but was only closing 2 of them.

## Changes

Added the missing closing parenthesis in both locations:

**Before:**
```
FILTER(range, BYROW(range, LAMBDA(r, SUMPRODUCT(...) >= threshold)),
```

**After:**
```
FILTER(range, BYROW(range, LAMBDA(r, SUMPRODUCT(...) >= threshold))),
```

## Testing

- ✅ Linter passes: `uv run scripts/lint_formulas.py`
- ✅ README generation passes: `uv run scripts/generate_readme.py`
- ✅ Parentheses balanced: All lines now show correct depth

## Impact

- Fixes DENSIFY formula (all modes)
- Fixes DENSIFYROWS (which calls DENSIFY)
- Both formulas should now work correctly in Google Sheets