### PR TITLE
Add required parameter examples and linter rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,9 @@ parameters:
   - name: param1
     description: Description of parameter
     example: "A1:B10"
+  - name: param2
+    description: Another parameter
+    example: '""'
 formula: |
   LET(
     variable, expression,
@@ -138,7 +141,9 @@ Formulas can call other named functions - the system automatically:
 
 **Key rules enforced:**
 - Formulas must not start with `=` (added during generation)
+- All parameters must have non-empty example values
 - Warns about self-executing LAMBDA patterns (can often be simplified)
+- Formulas must be syntactically valid per pyparsing grammar
 
 **Extensible**: Add new rules by subclassing `LintRule` and registering in the linter.
 
@@ -148,7 +153,7 @@ Formulas can call other named functions - the system automatically:
 1. Test in Google Sheets first before adding to repository
 2. Use composition - call existing named functions instead of duplicating logic
 3. Follow the 4-step workflow (lint → generate → test → commit both)
-4. Provide realistic parameter examples in YAML
+4. Provide non-empty example values for all parameters (linter enforces this; e.g., `"A1:B10"`, `'""'`, `BLANK()`, `0`)
 
 ### Parser Improvements
 1. Run parser tests first: `uv run pytest tests/test_formula_parser.py -v`

--- a/README.md
+++ b/README.md
@@ -1544,6 +1544,12 @@ A1:B10
 Value to use in place of non-errors
 ```
 
+**Example:**
+
+```
+""
+```
+
 </details>
 
 <details>

--- a/formulas/nonerrorsto.yaml
+++ b/formulas/nonerrorsto.yaml
@@ -14,7 +14,7 @@ parameters:
 
   - name: replacement
     description: Value to use in place of non-errors
-    example: ""
+    example: '""'
 
 formula: |
   MAP(input, LAMBDA(v, IF(ISERROR(v), v, replacement)))

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -91,9 +91,10 @@ Based on issues #95 and #96, future work should add tests for:
    - Multiple calls to same function
 
 3. **Linter rules**:
-   - Test each linter rule individually
+   - Test each linter rule individually (see `test_linter.py` for comprehensive examples)
    - Test that invalid formulas are caught
    - Test that valid formulas pass
+   - Parameter examples rule (`require-parameter-examples`): All parameters must have non-empty `example` fields; test edge cases like zero (`0`), falsy values, quoted strings (`'""'`), and function calls (`BLANK()`)
 
 ## Dependencies
 


### PR DESCRIPTION
This commit implements the `require-parameter-examples` linter rule to ensure all formula parameters have non-empty example values.

Changes:
- Add RequireParameterExamplesRule class to scripts/lint_formulas.py
  - Validates all parameters have non-empty 'example' fields
  - Supports edge cases: zero values, falsy values, quoted strings, BLANK()
  - Registered in FormulaLinter (4 rules now)

- Add comprehensive test suite (16 test cases) to tests/test_linter.py
  - TestRequireParameterExamplesRule with positive and negative cases
  - Test edge cases and error messages
  - Updated rule count assertion (3 -> 4 rules)

- Fix NONERRORSTO formula in formulas/nonerrorsto.yaml
  - Changed replacement parameter example from empty string to '""'
  - Represents the double-quoted empty string example

- Update documentation
  - CLAUDE.md: Example YAML, linter rules list, formula development best practices
  - tests/CLAUDE.md: Parameter examples rule documentation

- Regenerate README.md
  - NONERRORSTO replacement parameter now shows '""' as example

All tests pass (180 tests), linter validates all 33 formulas successfully.