### PR TITLE
Rename GitHub Actions workflows to reflect expanded scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: CI
 
 on:
   push:

--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -1,4 +1,4 @@
-name: Generate README
+name: Auto-update README
 
 on:
   push:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ This repository contains named Google Sheets formulas using LET and LAMBDA funct
 
 ```
 named-functions/
-├── .github/workflows/*.yml    # CI/CD: test.yml (quality gate), generate-readme.yml, claude.yml
+├── .github/workflows/*.yml    # CI/CD: ci.yml (quality gate), generate-readme.yml, claude.yml
 ├── formulas/*.yaml            # Individual formula definitions
 ├── scripts/                   # Python package with shared modules and scripts
 │   ├── __init__.py            # Package marker
@@ -88,8 +88,8 @@ git commit -m "Add/update YOUR_FORMULA"
 
 ### CI/CD
 
-- **test.yml**: Primary quality gate (runs tests, linter, generator, verifies README up-to-date)
-- **generate-readme.yml**: Auto-commits README on main, comments on PRs if stale
+- **ci.yml**: Primary quality gate (runs Python/YAML linting, tests, formula linter, README generation, verification)
+- **generate-readme.yml**: Auto-commits README on main, comments on PRs if stale (runs formula linter before generation)
 - **claude.yml**: Claude Code integration (restricted to git, uv, python commands)
 
 **Formula expansion failures block PR merges** - all formulas must be syntactically valid and fully expandable.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -66,7 +66,7 @@ def test_feature_name(self):
 
 ## CI Integration
 
-Tests run automatically on every push and PR via `.github/workflows/test.yml`:
+Tests run automatically on every push and PR via `.github/workflows/ci.yml`:
 - Installs pytest, pyyaml, pyparsing
 - Runs pytest test suite
 - Runs linter on all formulas


### PR DESCRIPTION
## Summary

Renamed GitHub Actions workflows to better reflect what they actually do:

- **`test.yml` → `ci.yml`**: The workflow does way more than just tests - it's a full CI pipeline that runs Python/YAML linting, pytest tests, formula linting, README generation, and verification
- **Workflow display names updated**:
  - "Run Tests" → "CI" (clearer and matches the new filename)
  - "Generate README" → "Auto-update README" (more accurately describes the auto-commit behavior)
- **Updated CLAUDE.md documentation** with more detailed descriptions of each workflow's scope

## Changes

- `.github/workflows/test.yml` renamed to `.github/workflows/ci.yml`
- Workflow name updated from "Run Tests" to "CI"
- `generate-readme.yml` display name updated to "Auto-update README"
- CLAUDE.md updated to reference `ci.yml` and provide clearer descriptions of what each workflow does

## Test plan

- [x] Verified all file changes are correct
- [x] Updated documentation reflects new workflow names
- [ ] CI pipeline will run with new workflow name
- [ ] Verify GitHub Actions UI shows updated workflow names